### PR TITLE
Fix master branch

### DIFF
--- a/buildbot_ros_cfg/distro.py
+++ b/buildbot_ros_cfg/distro.py
@@ -84,8 +84,8 @@ class RosDistroOracle:
 
             self.build_files[dist_name] = dict()
             # Get the packages name in order for building
+            self.ordered_packages[dist_name] = dict()
             for repo_name in dist.repositories:
-                self.ordered_packages[dist_name] = dict()
                 repo = dist.repositories[repo_name]
                 if repo.release_repository == None:
                     continue

--- a/buildbot_ros_cfg/ros_deb_master.py
+++ b/buildbot_ros_cfg/ros_deb_master.py
@@ -41,14 +41,22 @@ def ros_branch_build(c, job_name, packages, url, branch, distro, arch, rosdistro
             hideStepIf = success,
         )
     )
-    # Check out the repository master branch, since releases are tagged and not branched
+    # Pulling the repo
     f.addStep(
         Git(
             repourl = url,
-            branch = branch,
+            branch = 'HEAD',
             alwaysUseLatest = True, # this avoids broken builds when schedulers send wrong tag/rev
             mode = 'full', # clean out old versions
             getDescription={'tags': True}
+        )
+    )
+    # Check out the repository branch/commit/tag
+    f.addStep(
+        ShellCommand(
+            haltOnFailure = True,
+            name = 'checkout: ' + branch,
+            command = ['git', 'checkout', branch],
         )
     )
     # get the short commit hash


### PR DESCRIPTION
1- The ordered_packages dict being reset for each repo
2- Separate pulling the git repo from checking desired branch/commit/tag, previously it was failing when we use a commit as version